### PR TITLE
[WIP] Laws for minimum/maximum(By)Option 

### DIFF
--- a/alleycats-tests/shared/src/test/scala/alleycats/tests/IterableTests.scala
+++ b/alleycats-tests/shared/src/test/scala/alleycats/tests/IterableTests.scala
@@ -23,5 +23,5 @@ class IterableTests extends AlleycatsSuite {
       .value shouldEqual (Eval.now("OK").value)
   }
 
-  checkAll("Foldable[Iterable]", FoldableTests[Iterable].foldable[Int, Int])
+  checkAll("Foldable[Iterable]", FoldableTests[Iterable].foldable[Int, Int, Int])
 }

--- a/free/src/test/scala/cats/free/CofreeSuite.scala
+++ b/free/src/test/scala/cats/free/CofreeSuite.scala
@@ -17,12 +17,12 @@ class CofreeSuite extends CatsSuite {
   checkAll("Cofree[Option, *]", ComonadTests[Cofree[Option, *]].comonad[Int, Int, Int])
   locally {
     implicit val instance: Traverse[Cofree[Option, *]] = Cofree.catsTraverseForCofree[Option]
-    checkAll("Cofree[Option, *]", TraverseTests[Cofree[Option, *]].traverse[Int, Int, Int, Int, Option, Option])
+    checkAll("Cofree[Option, *]", TraverseTests[Cofree[Option, *]].traverse[Int, Int, Int, Int, Int, Option, Option])
     checkAll("Traverse[Cofree[Option, *]]", SerializableTests.serializable(Traverse[Cofree[Option, *]]))
   }
   locally {
     implicit val instance: Reducible[Cofree[Option, *]] = Cofree.catsReducibleForCofree[Option]
-    checkAll("Cofree[Option, *]", ReducibleTests[Cofree[Option, *]].reducible[Option, Int, Int])
+    checkAll("Cofree[Option, *]", ReducibleTests[Cofree[Option, *]].reducible[Option, Int, Int, Int])
     checkAll("Reducible[Cofree[Option, *]]", SerializableTests.serializable(Reducible[Cofree[Option, *]]))
   }
   checkAll("Comonad[Cofree[Option, *]]", SerializableTests.serializable(Comonad[Cofree[Option, *]]))

--- a/free/src/test/scala/cats/free/FreeSuite.scala
+++ b/free/src/test/scala/cats/free/FreeSuite.scala
@@ -30,13 +30,13 @@ class FreeSuite extends CatsSuite {
   locally {
     implicit val instance: Foldable[Free[Option, *]] = Free.catsFreeFoldableForFree[Option]
 
-    checkAll("Free[Option, *]", FoldableTests[Free[Option, *]].foldable[Int, Int])
+    checkAll("Free[Option, *]", FoldableTests[Free[Option, *]].foldable[Int, Int, Int])
     checkAll("Foldable[Free[Option,*]]", SerializableTests.serializable(Foldable[Free[Option, *]]))
   }
 
   locally {
     implicit val instance: Traverse[Free[Option, *]] = Free.catsFreeTraverseForFree[Option]
-    checkAll("Free[Option,*]", TraverseTests[Free[Option, *]].traverse[Int, Int, Int, Int, Option, Option])
+    checkAll("Free[Option,*]", TraverseTests[Free[Option, *]].traverse[Int, Int, Int, Int, Int, Option, Option])
     checkAll("Traverse[Free[Option,*]]", SerializableTests.serializable(Traverse[Free[Option, *]]))
   }
 

--- a/laws/src/main/scala/cats/laws/UnorderedFoldableLaws.scala
+++ b/laws/src/main/scala/cats/laws/UnorderedFoldableLaws.scala
@@ -51,6 +51,94 @@ trait UnorderedFoldableLaws[F[_]] {
   def nonEmptyRef[A](fa: F[A]): IsEq[Boolean] =
     F.nonEmpty(fa) <-> !F.isEmpty(fa)
 
+  /**
+   * If there are elements in `F[A]` there exists a minimum
+   */
+  def minimumOptionIsMinimal[A](fa: F[A])(implicit A: Order[A]): Boolean = {
+    val optMin = F.minimumOption(fa)
+    F.forall(fa) { a =>
+      optMin.exists { min =>
+        A.lteqv(min, a)
+      }
+    }
+  }
+
+  /**
+   * If `F[A]` has a minimum this minimum is contained in `F[A]`
+   */
+  def minimumOptionIsContained[A: Order](fa: F[A]): Boolean =
+    F.minimumOption(fa).forall { min =>
+      F.exists(fa) { a =>
+        Order.eqv(min, a)
+      }
+    }
+
+  /**
+   * If there are elements in `F[A]` there exists a maximum
+   */
+  def maximumOptionIsMaximal[A](fa: F[A])(implicit A: Order[A]): Boolean = {
+    val optMax = F.maximumOption(fa)
+    F.forall(fa) { a =>
+      optMax.exists { max =>
+        A.gteqv(max, a)
+      }
+    }
+  }
+
+  /**
+   * If `F[A]` has a maximum this maximum is contained in `F[A]`
+   */
+  def maximumOptionIsContained[A: Order](fa: F[A]): Boolean =
+    F.maximumOption(fa).forall { max =>
+      F.exists(fa) { a =>
+        Order.eqv(max, a)
+      }
+    }
+
+  /**
+   * If there are elements in `F[A]` there exists a minimum by measure f
+   */
+  def minimumByOptionIsMinimal[A, B](fa: F[A], f: A => B)(implicit B: Order[B]): Boolean = {
+    val optMin = F.minimumByOption(fa)(f).map(f)
+    F.forall(fa) { a =>
+      optMin.exists { min =>
+        B.lteqv(min, f(a))
+      }
+    }
+  }
+
+  /**
+   * If `F[A]` has a minimum by some measure f this minimum is contained in `F[A]`
+   */
+  def minimumByOptionIsContained[A, B: Order](fa: F[A], f: A => B)(implicit A: Equiv[A]): Boolean =
+    F.minimumByOption(fa)(f).forall { min =>
+      F.exists(fa) { a =>
+        A.equiv(min, a)
+      }
+    }
+
+  /**
+   * If there are elements in `F[A]` there exists a maximum by measure f
+   */
+  def maximumByOptionIsMaximal[A, B](fa: F[A], f: A => B)(implicit B: Order[B]): Boolean = {
+    val optMax = F.maximumByOption(fa)(f).map(f)
+    F.forall(fa) { a =>
+      optMax.exists { max =>
+        B.gteqv(max, f(a))
+      }
+    }
+  }
+
+  /**
+   * If `F[A]` has a maximum by some measure f this maximum is contained in `F[A]`
+   */
+  def maximumByOptionIsContained[A, B: Order](fa: F[A], f: A => B)(implicit A: Equiv[A]): Boolean =
+    F.maximumByOption(fa)(f).forall { max =>
+      F.exists(fa) { a =>
+        A.equiv(max, a)
+      }
+    }
+
 }
 
 object UnorderedFoldableLaws {

--- a/laws/src/main/scala/cats/laws/discipline/FoldableTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/FoldableTests.scala
@@ -11,20 +11,21 @@ import arbitrary.catsLawsArbitraryForPartialFunction
 trait FoldableTests[F[_]] extends UnorderedFoldableTests[F] {
   def laws: FoldableLaws[F]
 
-  def foldable[A: Arbitrary, B: Arbitrary](implicit
-                                           ArbFA: Arbitrary[F[A]],
-                                           A: CommutativeMonoid[A],
-                                           B: CommutativeMonoid[B],
-                                           CogenA: Cogen[A],
-                                           CogenB: Cogen[B],
-                                           EqA: Eq[A],
-                                           EqFA: Eq[F[A]],
-                                           EqB: Eq[B],
-                                           EqOptionB: Eq[Option[B]],
-                                           EqOptionA: Eq[Option[A]]): RuleSet =
+  def foldable[A: Arbitrary, B: Arbitrary, C: Order](implicit
+                                                     ArbFA: Arbitrary[F[A]],
+                                                     ArbFC: Arbitrary[F[C]],
+                                                     A: CommutativeMonoid[A],
+                                                     B: CommutativeMonoid[B],
+                                                     CogenA: Cogen[A],
+                                                     CogenB: Cogen[B],
+                                                     EqA: Eq[A],
+                                                     EqFA: Eq[F[A]],
+                                                     EqB: Eq[B],
+                                                     EqOptionB: Eq[Option[B]],
+                                                     EqOptionA: Eq[Option[A]]): RuleSet =
     new DefaultRuleSet(
       name = "foldable",
-      parent = Some(unorderedFoldable[A, B]),
+      parent = Some(unorderedFoldable[A, B, C]),
       "foldLeft consistent with foldMap" -> forAll(laws.leftFoldConsistentWithFoldMap[A, B] _),
       "foldRight consistent with foldMap" -> forAll(laws.rightFoldConsistentWithFoldMap[A, B] _),
       "foldRight is lazy" -> forAll(laws.foldRightLazy[A] _),

--- a/laws/src/main/scala/cats/laws/discipline/NonEmptyTraverseTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/NonEmptyTraverseTests.scala
@@ -2,16 +2,17 @@ package cats.laws.discipline
 
 import org.scalacheck.{Arbitrary, Cogen, Prop}
 import Prop.forAll
-import cats.kernel.CommutativeMonoid
+import cats.kernel.{CommutativeMonoid, Order}
 import cats.{Applicative, CommutativeApplicative, Eq, NonEmptyTraverse}
 import cats.laws.NonEmptyTraverseLaws
 
 trait NonEmptyTraverseTests[F[_]] extends TraverseTests[F] with ReducibleTests[F] {
   def laws: NonEmptyTraverseLaws[F]
 
-  def nonEmptyTraverse[G[_]: Applicative, A: Arbitrary, B: Arbitrary, C: Arbitrary, M: Arbitrary, X[_], Y[_]](
+  def nonEmptyTraverse[G[_]: Applicative, A: Arbitrary, B: Arbitrary, C: Arbitrary, D: Order, M: Arbitrary, X[_], Y[_]](
     implicit
     ArbFA: Arbitrary[F[A]],
+    ArbFD: Arbitrary[F[D]],
     ArbXB: Arbitrary[X[B]],
     ArbYB: Arbitrary[Y[B]],
     ArbYC: Arbitrary[Y[C]],
@@ -52,7 +53,7 @@ trait NonEmptyTraverseTests[F[_]] extends TraverseTests[F] with ReducibleTests[F
     new RuleSet {
       def name: String = "nonEmptyTraverse"
       def bases: Seq[(String, RuleSet)] = Nil
-      def parents: Seq[RuleSet] = Seq(traverse[A, B, C, M, X, Y], reducible[G, A, B])
+      def parents: Seq[RuleSet] = Seq(traverse[A, B, C, D, M, X, Y], reducible[G, A, B, D])
       def props: Seq[(String, Prop)] = Seq(
         "nonEmptyTraverse identity" -> forAll(laws.nonEmptyTraverseIdentity[A, C] _),
         "nonEmptyTraverse sequential composition" -> forAll(

--- a/laws/src/main/scala/cats/laws/discipline/ReducibleTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ReducibleTests.scala
@@ -11,23 +11,24 @@ import org.scalacheck.Prop.forAll
 trait ReducibleTests[F[_]] extends FoldableTests[F] {
   def laws: ReducibleLaws[F]
 
-  def reducible[G[_]: Applicative, A: Arbitrary, B: Arbitrary](implicit
-                                                               ArbFA: Arbitrary[F[A]],
-                                                               ArbFB: Arbitrary[F[B]],
-                                                               ArbFGA: Arbitrary[F[G[A]]],
-                                                               ArbGB: Arbitrary[G[B]],
-                                                               CogenA: Cogen[A],
-                                                               CogenB: Cogen[B],
-                                                               EqG: Eq[G[Unit]],
-                                                               EqA: Eq[A],
-                                                               EqB: Eq[B],
-                                                               EqFA: Eq[F[A]],
-                                                               EqOptionA: Eq[Option[A]],
-                                                               MonoidA: CommutativeMonoid[A],
-                                                               MonoidB: CommutativeMonoid[B]): RuleSet =
+  def reducible[G[_]: Applicative, A: Arbitrary, B: Arbitrary, C: Order](implicit
+                                                                         ArbFA: Arbitrary[F[A]],
+                                                                         ArbFB: Arbitrary[F[B]],
+                                                                         ArbFC: Arbitrary[F[C]],
+                                                                         ArbFGA: Arbitrary[F[G[A]]],
+                                                                         ArbGB: Arbitrary[G[B]],
+                                                                         CogenA: Cogen[A],
+                                                                         CogenB: Cogen[B],
+                                                                         EqG: Eq[G[Unit]],
+                                                                         EqA: Eq[A],
+                                                                         EqB: Eq[B],
+                                                                         EqFA: Eq[F[A]],
+                                                                         EqOptionA: Eq[Option[A]],
+                                                                         MonoidA: CommutativeMonoid[A],
+                                                                         MonoidB: CommutativeMonoid[B]): RuleSet =
     new DefaultRuleSet(
       name = "reducible",
-      parent = Some(foldable[A, B]),
+      parent = Some(foldable[A, B, C]),
       "reduceLeftTo consistent with reduceMap" -> forAll(laws.reduceLeftToConsistentWithReduceMap[A, B] _),
       "reduceRightTo consistent with reduceMap" -> forAll(laws.reduceRightToConsistentWithReduceMap[A, B] _),
       "reduceRightTo consistent with reduceRightToOption" ->

--- a/laws/src/main/scala/cats/laws/discipline/TraverseTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/TraverseTests.scala
@@ -10,10 +10,11 @@ import Prop._
 trait TraverseTests[F[_]] extends FunctorTests[F] with FoldableTests[F] with UnorderedTraverseTests[F] {
   def laws: TraverseLaws[F]
 
-  def traverse[A: Arbitrary, B: Arbitrary, C: Arbitrary, M: Arbitrary, X[_]: CommutativeApplicative, Y[_]: CommutativeApplicative](
+  def traverse[A: Arbitrary, B: Arbitrary, C: Arbitrary, D: Order, M: Arbitrary, X[_]: CommutativeApplicative, Y[_]: CommutativeApplicative](
     implicit
     ArbFA: Arbitrary[F[A]],
     ArbFB: Arbitrary[F[B]],
+    ArbFD: Arbitrary[F[D]],
     ArbXB: Arbitrary[X[B]],
     ArbXM: Arbitrary[X[M]],
     ArbYB: Arbitrary[Y[B]],
@@ -44,7 +45,7 @@ trait TraverseTests[F[_]] extends FunctorTests[F] with FoldableTests[F] with Uno
     new RuleSet {
       def name: String = "traverse"
       def bases: Seq[(String, RuleSet)] = Nil
-      def parents: Seq[RuleSet] = Seq(functor[A, B, C], foldable[A, M], unorderedTraverse[A, M, C, X, Y])
+      def parents: Seq[RuleSet] = Seq(functor[A, B, C], foldable[A, M, D], unorderedTraverse[A, M, C, D, X, Y])
       def props: Seq[(String, Prop)] = Seq(
         "traverse identity" -> forAll(laws.traverseIdentity[A, C] _),
         "traverse sequential composition" -> forAll(laws.traverseSequentialComposition[A, B, C, X, Y] _),

--- a/laws/src/main/scala/cats/laws/discipline/UnorderedFoldableTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/UnorderedFoldableTests.scala
@@ -11,15 +11,16 @@ import cats.instances.boolean._
 trait UnorderedFoldableTests[F[_]] extends Laws {
   def laws: UnorderedFoldableLaws[F]
 
-  def unorderedFoldable[A: Arbitrary, B: Arbitrary](implicit
-                                                    ArbFA: Arbitrary[F[A]],
-                                                    ArbF: Arbitrary[A => B],
-                                                    CogenA: Cogen[A],
-                                                    A: CommutativeMonoid[A],
-                                                    B: CommutativeMonoid[B],
-                                                    EqFA: Eq[A],
-                                                    EqFB: Eq[B],
-                                                    EqOptionA: Eq[Option[A]]): RuleSet =
+  def unorderedFoldable[A: Arbitrary, B: Arbitrary, C: Order](implicit
+                                                              ArbFA: Arbitrary[F[A]],
+                                                              ArbFC: Arbitrary[F[C]],
+                                                              ArbF: Arbitrary[A => B],
+                                                              CogenA: Cogen[A],
+                                                              A: CommutativeMonoid[A],
+                                                              B: CommutativeMonoid[B],
+                                                              EqFA: Eq[A],
+                                                              EqFB: Eq[B],
+                                                              EqOptionA: Eq[Option[A]]): RuleSet =
     new DefaultRuleSet(
       name = "unorderedFoldable",
       parent = None,
@@ -31,7 +32,11 @@ trait UnorderedFoldableTests[F[_]] extends Laws {
       "forall true if empty" -> forAll(laws.forallEmpty[A] _),
       "nonEmpty reference" -> forAll(laws.nonEmptyRef[A] _),
       "exists is lazy" -> forAll(laws.existsLazy[A] _),
-      "forall is lazy" -> forAll(laws.forallLazy[A] _)
+      "forall is lazy" -> forAll(laws.forallLazy[A] _),
+      "minimumOption is minimal" -> forAll(laws.minimumOptionIsMinimal[C] _),
+      "minimumOption is contained" -> forAll(laws.minimumOptionIsContained[C] _),
+      "maximumOption is maximal" -> forAll(laws.maximumOptionIsMaximal[C] _),
+      "maximumOption is contained" -> forAll(laws.maximumOptionIsContained[C] _)
     )
 }
 

--- a/laws/src/main/scala/cats/laws/discipline/UnorderedTraverseTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/UnorderedTraverseTests.scala
@@ -9,8 +9,9 @@ import cats.kernel.CommutativeMonoid
 trait UnorderedTraverseTests[F[_]] extends UnorderedFoldableTests[F] {
   def laws: UnorderedTraverseLaws[F]
 
-  def unorderedTraverse[A: Arbitrary, B: Arbitrary, C: Arbitrary, X[_]: CommutativeApplicative, Y[_]: CommutativeApplicative](
+  def unorderedTraverse[A: Arbitrary, B: Arbitrary, C: Arbitrary, D: Order, X[_]: CommutativeApplicative, Y[_]: CommutativeApplicative](
     implicit ArbFA: Arbitrary[F[A]],
+    ArbFD: Arbitrary[F[D]],
     ArbFXB: Arbitrary[F[X[B]]],
     ArbXB: Arbitrary[X[B]],
     ArbYB: Arbitrary[Y[B]],
@@ -32,7 +33,7 @@ trait UnorderedTraverseTests[F[_]] extends UnorderedFoldableTests[F] {
     }
     new DefaultRuleSet(
       name = "unorderedTraverse",
-      parent = Some(unorderedFoldable[A, B]),
+      parent = Some(unorderedFoldable[A, B, D]),
       "unordered traverse sequential composition" -> forAll(
         laws.unorderedTraverseSequentialComposition[A, B, C, X, Y] _
       ),

--- a/tests/src/test/scala-2.12/cats/tests/NonEmptyStreamSuite.scala
+++ b/tests/src/test/scala-2.12/cats/tests/NonEmptyStreamSuite.scala
@@ -16,10 +16,10 @@ class NonEmptyStreamSuite extends CatsSuite {
   checkAll("NonEmptyStream[Int]", EqTests[NonEmptyStream[Int]].eqv)
 
   checkAll("NonEmptyStream[Int] with Option",
-           NonEmptyTraverseTests[NonEmptyStream].nonEmptyTraverse[Option, Int, Int, Int, Int, Option, Option])
+           NonEmptyTraverseTests[NonEmptyStream].nonEmptyTraverse[Option, Int, Int, Int, Int, Int, Option, Option])
   checkAll("NonEmptyTraverse[NonEmptyStream[A]]", SerializableTests.serializable(NonEmptyTraverse[NonEmptyStream[*]]))
 
-  checkAll("NonEmptyStream[Int]", ReducibleTests[NonEmptyStream].reducible[Option, Int, Int])
+  checkAll("NonEmptyStream[Int]", ReducibleTests[NonEmptyStream].reducible[Option, Int, Int, Int])
   checkAll("Reducible[NonEmptyStream]", SerializableTests.serializable(Reducible[NonEmptyStream]))
 
   checkAll("NonEmptyStream[Int]", SemigroupTests[NonEmptyStream[Int]].semigroup)

--- a/tests/src/test/scala-2.13+/cats/tests/ArraySeqSuite.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/ArraySeqSuite.scala
@@ -20,7 +20,7 @@ class ArraySeqSuite extends CatsSuite {
   checkAll("ArraySeq[Int]", MonoidKTests[ArraySeq].monoidK[Int])
   checkAll("MonoidK[ArraySeq]", SerializableTests.serializable(MonoidK[ArraySeq]))
 
-  checkAll("ArraySeq[Int] with Option", TraverseTests[ArraySeq].traverse[Int, Int, Int, Set[Int], Option, Option])
+  checkAll("ArraySeq[Int] with Option", TraverseTests[ArraySeq].traverse[Int, Int, Int, Int, Set[Int], Option, Option])
   checkAll("Traverse[ArraySeq]", SerializableTests.serializable(Traverse[ArraySeq]))
 
   checkAll("ArraySeq[Int]", TraverseFilterTests[ArraySeq].traverseFilter[Int, Int, Int])

--- a/tests/src/test/scala-2.13+/cats/tests/LazyListSuite.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/LazyListSuite.scala
@@ -29,7 +29,7 @@ class LazyListSuite extends CatsSuite {
   checkAll("LazyList[Int]", MonadTests[LazyList].monad[Int, Int, Int])
   checkAll("Monad[LazyList]", SerializableTests.serializable(Monad[LazyList]))
 
-  checkAll("LazyList[Int] with Option", TraverseTests[LazyList].traverse[Int, Int, Int, Set[Int], Option, Option])
+  checkAll("LazyList[Int] with Option", TraverseTests[LazyList].traverse[Int, Int, Int, Int, Set[Int], Option, Option])
   checkAll("Traverse[LazyList]", SerializableTests.serializable(Traverse[LazyList]))
 
   checkAll("LazyList[Int]", TraverseFilterTests[LazyList].traverseFilter[Int, Int, Int])

--- a/tests/src/test/scala-2.13+/cats/tests/NonEmptyLazyListSuite.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/NonEmptyLazyListSuite.scala
@@ -18,7 +18,7 @@ class NonEmptyLazyListSuite extends CatsSuite {
   checkAll("SemigroupK[NonEmptyLazyList]", SerializableTests.serializable(SemigroupK[NonEmptyLazyList]))
 
   checkAll("NonEmptyLazyList[Int] with Option",
-           NonEmptyTraverseTests[NonEmptyLazyList].nonEmptyTraverse[Option, Int, Int, Int, Int, Option, Option])
+           NonEmptyTraverseTests[NonEmptyLazyList].nonEmptyTraverse[Option, Int, Int, Int, Int, Int, Option, Option])
   checkAll("NonEmptyTraverse[NonEmptyLazyList]", SerializableTests.serializable(Traverse[NonEmptyLazyList]))
 
   checkAll("NonEmptyLazyList[Int]", BimonadTests[NonEmptyLazyList].bimonad[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/ChainSuite.scala
+++ b/tests/src/test/scala/cats/tests/ChainSuite.scala
@@ -20,7 +20,7 @@ class ChainSuite extends CatsSuite {
   checkAll("Chain[Int]", AlternativeTests[Chain].alternative[Int, Int, Int])
   checkAll("Alternative[Chain]", SerializableTests.serializable(Alternative[Chain]))
 
-  checkAll("Chain[Int] with Option", TraverseTests[Chain].traverse[Int, Int, Int, Set[Int], Option, Option])
+  checkAll("Chain[Int] with Option", TraverseTests[Chain].traverse[Int, Int, Int, Int, Set[Int], Option, Option])
   checkAll("Traverse[Chain]", SerializableTests.serializable(Traverse[Chain]))
 
   checkAll("Chain[Int]", MonadTests[Chain].monad[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/ConstSuite.scala
+++ b/tests/src/test/scala/cats/tests/ConstSuite.scala
@@ -28,7 +28,7 @@ class ConstSuite extends CatsSuite {
   checkAll("Applicative[Const[String, *]]", SerializableTests.serializable(Applicative[Const[String, *]]))
 
   checkAll("Const[String, Int] with Option",
-           TraverseTests[Const[String, *]].traverse[Int, Int, Int, Int, Option, Option])
+           TraverseTests[Const[String, *]].traverse[Int, Int, Int, Int, Int, Option, Option])
   checkAll("Traverse[Const[String, *]]", SerializableTests.serializable(Traverse[Const[String, *]]))
 
   checkAll("Const[String, Int]", TraverseFilterTests[Const[String, *]].traverseFilter[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/EitherKSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherKSuite.scala
@@ -10,12 +10,12 @@ import cats.laws.discipline.eq._
 class EitherKSuite extends CatsSuite {
 
   checkAll("EitherK[Option, Option, *]",
-           TraverseTests[EitherK[Option, Option, *]].traverse[Int, Int, Int, Int, Option, Option])
+           TraverseTests[EitherK[Option, Option, *]].traverse[Int, Int, Int, Int, Int, Option, Option])
   checkAll("Traverse[EitherK[Option, Option, *]]", SerializableTests.serializable(Traverse[EitherK[Option, Option, *]]))
 
   {
     implicit val foldable: Foldable[EitherK[Option, Option, *]] = EitherK.catsDataFoldableForEitherK[Option, Option]
-    checkAll("EitherK[Option, Option, *]", FoldableTests[EitherK[Option, Option, *]].foldable[Int, Int])
+    checkAll("EitherK[Option, Option, *]", FoldableTests[EitherK[Option, Option, *]].foldable[Int, Int, Int])
     checkAll("Foldable[EitherK[Option, Option, *]]",
              SerializableTests.serializable(Foldable[EitherK[Option, Option, *]]))
   }

--- a/tests/src/test/scala/cats/tests/EitherSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherSuite.scala
@@ -27,7 +27,8 @@ class EitherSuite extends CatsSuite {
   checkAll("Either[Int, Int]", MonadErrorTests[Either[Int, *], Int].monadError[Int, Int, Int])
   checkAll("MonadError[Either[Int, *]]", SerializableTests.serializable(MonadError[Either[Int, *], Int]))
 
-  checkAll("Either[Int, Int] with Option", TraverseTests[Either[Int, *]].traverse[Int, Int, Int, Int, Option, Option])
+  checkAll("Either[Int, Int] with Option",
+           TraverseTests[Either[Int, *]].traverse[Int, Int, Int, Int, Int, Option, Option])
   checkAll("Traverse[Either[Int, *]", SerializableTests.serializable(Traverse[Either[Int, *]]))
 
   checkAll("Either[*, *]", BitraverseTests[Either].bitraverse[Option, Int, Int, Int, String, String, String])

--- a/tests/src/test/scala/cats/tests/EitherTSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherTSuite.scala
@@ -49,7 +49,7 @@ class EitherTSuite extends CatsSuite {
     implicit val F: Traverse[ListWrapper] = ListWrapper.traverse
 
     checkAll("EitherT[ListWrapper, Int, *]",
-             TraverseTests[EitherT[ListWrapper, Int, *]].traverse[Int, Int, Int, Int, Option, Option])
+             TraverseTests[EitherT[ListWrapper, Int, *]].traverse[Int, Int, Int, Int, Int, Option, Option])
     checkAll("Traverse[EitherT[ListWrapper, Int, *]]",
              SerializableTests.serializable(Traverse[EitherT[ListWrapper, Int, *]]))
     checkAll("EitherT[ListWrapper, *, *]",
@@ -117,7 +117,7 @@ class EitherTSuite extends CatsSuite {
     // if a foldable is defined
     implicit val F: Foldable[ListWrapper] = ListWrapper.foldable
 
-    checkAll("EitherT[ListWrapper, Int, *]", FoldableTests[EitherT[ListWrapper, Int, *]].foldable[Int, Int])
+    checkAll("EitherT[ListWrapper, Int, *]", FoldableTests[EitherT[ListWrapper, Int, *]].foldable[Int, Int, Int])
     checkAll("Foldable[EitherT[ListWrapper, Int, *]]",
              SerializableTests.serializable(Foldable[EitherT[ListWrapper, Int, *]]))
   }

--- a/tests/src/test/scala/cats/tests/EvalSuite.scala
+++ b/tests/src/test/scala/cats/tests/EvalSuite.scala
@@ -107,7 +107,7 @@ class EvalSuite extends CatsSuite {
 
   checkAll("Bimonad[Eval]", SerializableTests.serializable(Bimonad[Eval]))
 
-  checkAll("Eval[Int]", ReducibleTests[Eval].reducible[Option, Int, Int])
+  checkAll("Eval[Int]", ReducibleTests[Eval].reducible[Option, Int, Int, Int])
   checkAll("Reducible[Eval]", SerializableTests.serializable(Reducible[Eval]))
 
   checkAll("Eval[Int]", GroupTests[Eval[Int]].group)

--- a/tests/src/test/scala/cats/tests/IdSuite.scala
+++ b/tests/src/test/scala/cats/tests/IdSuite.scala
@@ -13,9 +13,9 @@ class IdSuite extends CatsSuite {
   checkAll("Id[Int]", CommutativeMonadTests[Id].commutativeMonad[Int, Int, Int])
   checkAll("CommutativeMonad[Id]", SerializableTests.serializable(CommutativeMonad[Id]))
 
-  checkAll("Id[Int]", TraverseTests[Id].traverse[Int, Int, Int, Int, Option, Option])
+  checkAll("Id[Int]", TraverseTests[Id].traverse[Int, Int, Int, Int, Int, Option, Option])
   checkAll("Traverse[Id]", SerializableTests.serializable(Traverse[Id]))
 
-  checkAll("Id[Int]", ReducibleTests[Id].reducible[Option, Int, Int])
+  checkAll("Id[Int]", ReducibleTests[Id].reducible[Option, Int, Int, Int])
   checkAll("Reducible[Id]", SerializableTests.serializable(Reducible[Id]))
 }

--- a/tests/src/test/scala/cats/tests/IdTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IdTSuite.scala
@@ -79,7 +79,7 @@ class IdTSuite extends CatsSuite {
   {
     implicit val F: Foldable[ListWrapper] = ListWrapper.foldable
 
-    checkAll("IdT[ListWrapper, Int]", FoldableTests[IdT[ListWrapper, *]].foldable[Int, Int])
+    checkAll("IdT[ListWrapper, Int]", FoldableTests[IdT[ListWrapper, *]].foldable[Int, Int, Int])
     checkAll("Foldable[IdT[ListWrapper, *]]", SerializableTests.serializable(Foldable[IdT[ListWrapper, *]]))
   }
 
@@ -87,15 +87,17 @@ class IdTSuite extends CatsSuite {
     implicit val F: Traverse[ListWrapper] = ListWrapper.traverse
 
     checkAll("IdT[ListWrapper, Int] with Option",
-             TraverseTests[IdT[ListWrapper, *]].traverse[Int, Int, Int, Int, Option, Option])
+             TraverseTests[IdT[ListWrapper, *]].traverse[Int, Int, Int, Int, Int, Option, Option])
     checkAll("Traverse[IdT[ListWrapper, *]]", SerializableTests.serializable(Traverse[IdT[ListWrapper, *]]))
   }
 
   {
     implicit val F: Traverse[NonEmptyList] = NonEmptyList.catsDataInstancesForNonEmptyList
 
-    checkAll("IdT[NonEmptyList, Int]",
-             NonEmptyTraverseTests[IdT[NonEmptyList, *]].nonEmptyTraverse[Option, Int, Int, Int, Int, Option, Option])
+    checkAll(
+      "IdT[NonEmptyList, Int]",
+      NonEmptyTraverseTests[IdT[NonEmptyList, *]].nonEmptyTraverse[Option, Int, Int, Int, Int, Int, Option, Option]
+    )
     checkAll("NonEmptyTraverse[IdT[NonEmptyList, *]]",
              SerializableTests.serializable(NonEmptyTraverse[IdT[NonEmptyList, *]]))
   }

--- a/tests/src/test/scala/cats/tests/IorSuite.scala
+++ b/tests/src/test/scala/cats/tests/IorSuite.scala
@@ -27,7 +27,8 @@ class IorSuite extends CatsSuite {
   checkAll("Ior[String, Int]", MonadErrorTests[Ior[String, *], String].monadError[Int, Int, Int])
   checkAll("MonadError[SIor[String, *]]", SerializableTests.serializable(MonadError[Ior[String, *], String]))
 
-  checkAll("Ior[String, Int] with Option", TraverseTests[Ior[String, *]].traverse[Int, Int, Int, Int, Option, Option])
+  checkAll("Ior[String, Int] with Option",
+           TraverseTests[Ior[String, *]].traverse[Int, Int, Int, Int, Int, Option, Option])
   checkAll("Traverse[Ior[String, *]]", SerializableTests.serializable(Traverse[Ior[String, *]]))
   checkAll("Ior[*, *]", BifunctorTests[Ior].bifunctor[Int, Int, Int, String, String, String])
 

--- a/tests/src/test/scala/cats/tests/IorTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IorTSuite.scala
@@ -25,7 +25,7 @@ class IorTSuite extends CatsSuite {
     implicit val F: Traverse[ListWrapper] = ListWrapper.traverse
 
     checkAll("IorT[ListWrapper, Int, *]",
-             TraverseTests[IorT[ListWrapper, Int, *]].traverse[Int, Int, Int, Int, Option, Option])
+             TraverseTests[IorT[ListWrapper, Int, *]].traverse[Int, Int, Int, Int, Int, Option, Option])
     checkAll("Traverse[IorT[ListWrapper, Int, *]]", SerializableTests.serializable(Traverse[IorT[ListWrapper, Int, *]]))
   }
 
@@ -50,7 +50,7 @@ class IorTSuite extends CatsSuite {
   {
     implicit val F: Foldable[ListWrapper] = ListWrapper.foldable
 
-    checkAll("IorT[ListWrapper, Int, *]", FoldableTests[IorT[ListWrapper, Int, *]].foldable[Int, Int])
+    checkAll("IorT[ListWrapper, Int, *]", FoldableTests[IorT[ListWrapper, Int, *]].foldable[Int, Int, Int])
     checkAll("Foldable[IorT[ListWrapper, Int, *]]", SerializableTests.serializable(Foldable[IorT[ListWrapper, Int, *]]))
   }
 

--- a/tests/src/test/scala/cats/tests/ListSuite.scala
+++ b/tests/src/test/scala/cats/tests/ListSuite.scala
@@ -27,7 +27,7 @@ class ListSuite extends CatsSuite {
   checkAll("List[Int]", AlternativeTests[List].alternative[Int, Int, Int])
   checkAll("Alternative[List]", SerializableTests.serializable(Alternative[List]))
 
-  checkAll("List[Int] with Option", TraverseTests[List].traverse[Int, Int, Int, Set[Int], Option, Option])
+  checkAll("List[Int] with Option", TraverseTests[List].traverse[Int, Int, Int, Int, Set[Int], Option, Option])
   checkAll("Traverse[List]", SerializableTests.serializable(Traverse[List]))
 
   checkAll("List[Int]", MonadTests[List].monad[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/MapSuite.scala
+++ b/tests/src/test/scala/cats/tests/MapSuite.scala
@@ -24,7 +24,7 @@ class MapSuite extends CatsSuite {
   checkAll("FlatMap[Map[Int, *]]", SerializableTests.serializable(FlatMap[Map[Int, *]]))
 
   checkAll("Map[Int, Int] with Option",
-           UnorderedTraverseTests[Map[Int, *]].unorderedTraverse[Int, Int, Int, Option, Option])
+           UnorderedTraverseTests[Map[Int, *]].unorderedTraverse[Int, Int, Int, Int, Option, Option])
   checkAll("UnorderedTraverse[Map[Int, *]]", SerializableTests.serializable(UnorderedTraverse[Map[Int, *]]))
 
   checkAll("Map[Int, Int]", FunctorFilterTests[Map[Int, *]].functorFilter[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/NestedSuite.scala
+++ b/tests/src/test/scala/cats/tests/NestedSuite.scala
@@ -171,7 +171,7 @@ class NestedSuite extends CatsSuite {
   {
     // Foldable composition
     implicit val instance: Foldable[ListWrapper] = ListWrapper.foldable
-    checkAll("Nested[List, ListWrapper, *]", FoldableTests[Nested[List, ListWrapper, *]].foldable[Int, Int])
+    checkAll("Nested[List, ListWrapper, *]", FoldableTests[Nested[List, ListWrapper, *]].foldable[Int, Int, Int])
     checkAll("Foldable[Nested[List, ListWrapper, *]]",
              SerializableTests.serializable(Foldable[Nested[List, ListWrapper, *]]))
   }
@@ -180,7 +180,7 @@ class NestedSuite extends CatsSuite {
     // Traverse composition
     implicit val instance: Traverse[ListWrapper] = ListWrapper.traverse
     checkAll("Nested[List, ListWrapper, *]",
-             TraverseTests[Nested[List, ListWrapper, *]].traverse[Int, Int, Int, Set[Int], Option, Option])
+             TraverseTests[Nested[List, ListWrapper, *]].traverse[Int, Int, Int, Int, Set[Int], Option, Option])
     checkAll("Traverse[Nested[List, ListWrapper, *]]",
              SerializableTests.serializable(Traverse[Nested[List, ListWrapper, *]]))
   }
@@ -189,7 +189,7 @@ class NestedSuite extends CatsSuite {
     // Reducible composition
     implicit val instance: Foldable[ListWrapper] = ListWrapper.foldable
     checkAll("Nested[NonEmptyList, OneAnd[ListWrapper, *], *]",
-             ReducibleTests[Nested[NonEmptyList, OneAnd[ListWrapper, *], *]].reducible[Option, Int, Int])
+             ReducibleTests[Nested[NonEmptyList, OneAnd[ListWrapper, *], *]].reducible[Option, Int, Int, Int])
     checkAll("Reducible[Nested[NonEmptyList, OneAnd[ListWrapper, *], *]]",
              SerializableTests.serializable(Reducible[Nested[NonEmptyList, OneAnd[ListWrapper, *], *]]))
   }
@@ -199,7 +199,7 @@ class NestedSuite extends CatsSuite {
     checkAll(
       "Nested[NonEmptyList, NonEmptyVector, *]",
       NonEmptyTraverseTests[Nested[NonEmptyList, NonEmptyVector, *]]
-        .nonEmptyTraverse[Option, Int, Int, Int, Int, Option, Option]
+        .nonEmptyTraverse[Option, Int, Int, Int, Int, Int, Option, Option]
     )
     checkAll("NonEmptyTraverse[Nested[NonEmptyList, NonEmptyVector, *]]",
              SerializableTests.serializable(NonEmptyTraverse[Nested[NonEmptyList, NonEmptyVector, *]]))

--- a/tests/src/test/scala/cats/tests/NonEmptyChainSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyChainSuite.scala
@@ -11,7 +11,7 @@ class NonEmptyChainSuite extends CatsSuite {
   checkAll("SemigroupK[NonEmptyChain]", SerializableTests.serializable(SemigroupK[NonEmptyChain]))
 
   checkAll("NonEmptyChain[Int] with Option",
-           NonEmptyTraverseTests[NonEmptyChain].nonEmptyTraverse[Option, Int, Int, Int, Int, Option, Option])
+           NonEmptyTraverseTests[NonEmptyChain].nonEmptyTraverse[Option, Int, Int, Int, Int, Int, Option, Option])
   checkAll("NonEmptyTraverse[NonEmptyChain]", SerializableTests.serializable(Traverse[NonEmptyChain]))
 
   checkAll("NonEmptyChain[Int]", BimonadTests[NonEmptyChain].bimonad[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
@@ -26,10 +26,10 @@ class NonEmptyListSuite extends CatsSuite {
   checkAll("NonEmptyList[Int]", OrderTests[NonEmptyList[Int]].order)
 
   checkAll("NonEmptyList[Int] with Option",
-           NonEmptyTraverseTests[NonEmptyList].nonEmptyTraverse[Option, Int, Int, Int, Int, Option, Option])
+           NonEmptyTraverseTests[NonEmptyList].nonEmptyTraverse[Option, Int, Int, Int, Int, Int, Option, Option])
   checkAll("NonEmptyTraverse[NonEmptyList[A]]", SerializableTests.serializable(NonEmptyTraverse[NonEmptyList]))
 
-  checkAll("NonEmptyList[Int]", ReducibleTests[NonEmptyList].reducible[Option, Int, Int])
+  checkAll("NonEmptyList[Int]", ReducibleTests[NonEmptyList].reducible[Option, Int, Int, Int])
   checkAll("Reducible[NonEmptyList]", SerializableTests.serializable(Reducible[NonEmptyList]))
 
   checkAll("NonEmptyList[Int]", SemigroupKTests[NonEmptyList].semigroupK[Int])

--- a/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
@@ -13,7 +13,7 @@ class NonEmptyMapSuite extends CatsSuite {
   checkAll("NonEmptyMap[String, Int]", SemigroupKTests[NonEmptyMap[String, *]].semigroupK[Int])
   checkAll(
     "NonEmptyMap[String, Int]",
-    NonEmptyTraverseTests[NonEmptyMap[String, *]].nonEmptyTraverse[Option, Int, Int, Double, Int, Option, Option]
+    NonEmptyTraverseTests[NonEmptyMap[String, *]].nonEmptyTraverse[Option, Int, Int, Int, Double, Int, Option, Option]
   )
   checkAll("NonEmptyMap[String, Int]", BandTests[NonEmptyMap[String, Int]].band)
   checkAll("NonEmptyMap[String, Int]", EqTests[NonEmptyMap[String, Int]].eqv)

--- a/tests/src/test/scala/cats/tests/NonEmptySetSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptySetSuite.scala
@@ -14,7 +14,7 @@ class NonEmptySetSuite extends CatsSuite {
   checkAll("NonEmptySet[Int]", SemigroupKTests[NonEmptySet].semigroupK[Int])
   checkAll("SemigroupK[NonEmptySet[A]]", SerializableTests.serializable(SemigroupK[NonEmptySet]))
 
-  checkAll("NonEmptySet[Int]", ReducibleTests[NonEmptySet].reducible[Option, Int, Int])
+  checkAll("NonEmptySet[Int]", ReducibleTests[NonEmptySet].reducible[Option, Int, Int, Int])
   checkAll("Reducible[NonEmptySet]", SerializableTests.serializable(Reducible[NonEmptySet]))
 
   checkAll("NonEmptySet[String]", SemilatticeTests[NonEmptySet[String]].band)

--- a/tests/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
@@ -29,10 +29,10 @@ class NonEmptyVectorSuite extends CatsSuite {
   checkAll("NonEmptyVector[Int]", EqTests[NonEmptyVector[Int]].eqv)
 
   checkAll("NonEmptyVector[Int] with Option",
-           NonEmptyTraverseTests[NonEmptyVector].nonEmptyTraverse[Option, Int, Int, Int, Int, Option, Option])
+           NonEmptyTraverseTests[NonEmptyVector].nonEmptyTraverse[Option, Int, Int, Int, Int, Int, Option, Option])
   checkAll("NonEmptyTraverse[NonEmptyVector[A]]", SerializableTests.serializable(NonEmptyTraverse[NonEmptyVector]))
 
-  checkAll("NonEmptyVector[Int]", ReducibleTests[NonEmptyVector].reducible[Option, Int, Int])
+  checkAll("NonEmptyVector[Int]", ReducibleTests[NonEmptyVector].reducible[Option, Int, Int, Int])
   checkAll("Reducible[NonEmptyVector]", SerializableTests.serializable(Reducible[NonEmptyVector]))
 
   // Test instances that have more general constraints
@@ -42,7 +42,7 @@ class NonEmptyVectorSuite extends CatsSuite {
   checkAll("SemigroupK[NonEmptyVector]", SerializableTests.serializable(SemigroupK[NonEmptyVector]))
   checkAll("Semigroup[NonEmptyVector[Int]]", SerializableTests.serializable(Semigroup[NonEmptyVector[Int]]))
 
-  checkAll("NonEmptyVector[Int]", FoldableTests[NonEmptyVector].foldable[Int, Int])
+  checkAll("NonEmptyVector[Int]", FoldableTests[NonEmptyVector].foldable[Int, Int, Int])
   checkAll("Foldable[NonEmptyVector]", SerializableTests.serializable(Foldable[NonEmptyVector]))
 
   checkAll("NonEmptyVector[Int]", AlignTests[NonEmptyVector].align[Int, Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/OneAndSuite.scala
+++ b/tests/src/test/scala/cats/tests/OneAndSuite.scala
@@ -14,7 +14,7 @@ class OneAndSuite extends CatsSuite {
   {
     implicit val traverse: Traverse[OneAnd[ListWrapper, *]] = OneAnd.catsDataTraverseForOneAnd(ListWrapper.traverse)
     checkAll("OneAnd[ListWrapper, Int] with Option",
-             TraverseTests[OneAnd[ListWrapper, *]].traverse[Int, Int, Int, Int, Option, Option])
+             TraverseTests[OneAnd[ListWrapper, *]].traverse[Int, Int, Int, Int, Int, Option, Option])
     checkAll("Traverse[OneAnd[ListWrapper, A]]", SerializableTests.serializable(Traverse[OneAnd[ListWrapper, *]]))
   }
 
@@ -49,7 +49,7 @@ class OneAndSuite extends CatsSuite {
 
   {
     implicit val foldable: Foldable[ListWrapper] = ListWrapper.foldable
-    checkAll("OneAnd[ListWrapper, Int]", FoldableTests[OneAnd[ListWrapper, *]].foldable[Int, Int])
+    checkAll("OneAnd[ListWrapper, Int]", FoldableTests[OneAnd[ListWrapper, *]].foldable[Int, Int, Int])
     checkAll("Foldable[OneAnd[ListWrapper, A]]", SerializableTests.serializable(Foldable[OneAnd[ListWrapper, *]]))
   }
 

--- a/tests/src/test/scala/cats/tests/OptionSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionSuite.scala
@@ -18,7 +18,7 @@ class OptionSuite extends CatsSuite {
   checkAll("Option[Int]", CommutativeMonadTests[Option].commutativeMonad[Int, Int, Int])
   checkAll("CommutativeMonad[Option]", SerializableTests.serializable(CommutativeMonad[Option]))
 
-  checkAll("Option[Int] with Option", TraverseTests[Option].traverse[Int, Int, Int, Int, Option, Option])
+  checkAll("Option[Int] with Option", TraverseTests[Option].traverse[Int, Int, Int, Int, Int, Option, Option])
   checkAll("Traverse[Option]", SerializableTests.serializable(Traverse[Option]))
 
   checkAll("Option[Int] with Option", TraverseFilterTests[Option].traverseFilter[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/OptionTSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionTSuite.scala
@@ -144,7 +144,7 @@ class OptionTSuite extends CatsSuite {
     // F has a Foldable
     implicit val F: Foldable[ListWrapper] = ListWrapper.foldable
 
-    checkAll("OptionT[ListWrapper, Int]", FoldableTests[OptionT[ListWrapper, *]].foldable[Int, Int])
+    checkAll("OptionT[ListWrapper, Int]", FoldableTests[OptionT[ListWrapper, *]].foldable[Int, Int, Int])
     checkAll("Foldable[OptionT[ListWrapper, *]]", SerializableTests.serializable(Foldable[OptionT[ListWrapper, *]]))
   }
 
@@ -153,7 +153,7 @@ class OptionTSuite extends CatsSuite {
     implicit val F: Traverse[ListWrapper] = ListWrapper.traverse
 
     checkAll("OptionT[ListWrapper, Int] with Option",
-             TraverseTests[OptionT[ListWrapper, *]].traverse[Int, Int, Int, Int, Option, Option])
+             TraverseTests[OptionT[ListWrapper, *]].traverse[Int, Int, Int, Int, Int, Option, Option])
     checkAll("Traverse[OptionT[ListWrapper, *]]", SerializableTests.serializable(Traverse[OptionT[ListWrapper, *]]))
 
     Foldable[OptionT[ListWrapper, *]]

--- a/tests/src/test/scala/cats/tests/QueueSuite.scala
+++ b/tests/src/test/scala/cats/tests/QueueSuite.scala
@@ -25,7 +25,7 @@ class QueueSuite extends CatsSuite {
   checkAll("Queue[Int]", MonadTests[Queue].monad[Int, Int, Int])
   checkAll("Monad[Queue]", SerializableTests.serializable(Monad[Queue]))
 
-  checkAll("Queue[Int] with Option", TraverseTests[Queue].traverse[Int, Int, Int, Set[Int], Option, Option])
+  checkAll("Queue[Int] with Option", TraverseTests[Queue].traverse[Int, Int, Int, Int, Set[Int], Option, Option])
   checkAll("Traverse[Queue]", SerializableTests.serializable(Traverse[Queue]))
 
   checkAll("Queue[Int]", TraverseFilterTests[Queue].traverseFilter[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/SetSuite.scala
+++ b/tests/src/test/scala/cats/tests/SetSuite.scala
@@ -12,7 +12,7 @@ class SetSuite extends CatsSuite {
   checkAll("Set[Int]", MonoidKTests[Set].monoidK[Int])
   checkAll("MonoidK[Set]", SerializableTests.serializable(MonoidK[Set]))
 
-  checkAll("Set[Int]", UnorderedTraverseTests[Set].unorderedTraverse[Int, Int, Int, Validated[Int, *], Option])
+  checkAll("Set[Int]", UnorderedTraverseTests[Set].unorderedTraverse[Int, Int, Int, Int, Validated[Int, *], Option])
   checkAll("UnorderedTraverse[Set]", SerializableTests.serializable(UnorderedTraverse[Set]))
 
   test("show") {

--- a/tests/src/test/scala/cats/tests/SortedMapSuite.scala
+++ b/tests/src/test/scala/cats/tests/SortedMapSuite.scala
@@ -27,7 +27,7 @@ class SortedMapSuite extends CatsSuite {
   checkAll("FlatMap[SortedMap[Int, *]]", SerializableTests.serializable(FlatMap[SortedMap[Int, *]]))
 
   checkAll("SortedMap[Int, Int] with Option",
-           TraverseTests[SortedMap[Int, *]].traverse[Int, Int, Int, Int, Option, Option])
+           TraverseTests[SortedMap[Int, *]].traverse[Int, Int, Int, Int, Int, Option, Option])
   checkAll("Traverse[SortedMap[Int, *]]", SerializableTests.serializable(Traverse[SortedMap[Int, *]]))
 
   checkAll("SortedMap[Int, Int]", TraverseFilterTests[SortedMap[Int, *]].traverseFilter[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/SortedSetSuite.scala
+++ b/tests/src/test/scala/cats/tests/SortedSetSuite.scala
@@ -18,7 +18,7 @@ class SortedSetSuite extends CatsSuite {
   checkAll("SemigroupK[SortedSet]", SerializableTests.serializable(SemigroupK[SortedSet]))
   checkAll("Semigroupal[SortedSet]", SerializableTests.serializable(Semigroupal[SortedSet]))
 
-  checkAll("SortedSet[Int]", FoldableTests[SortedSet].foldable[Int, Int])
+  checkAll("SortedSet[Int]", FoldableTests[SortedSet].foldable[Int, Int, Int])
   checkAll("Order[SortedSet[Int]]", OrderTests[SortedSet[Int]].order)
   checkAll("Order.reverse(Order[SortedSet[Int]])", OrderTests(Order.reverse(Order[SortedSet[Int]])).order)
   checkAll("PartialOrder[SortedSet[Int]]", PartialOrderTests[SortedSet[Int]].partialOrder)

--- a/tests/src/test/scala/cats/tests/StreamSuite.scala
+++ b/tests/src/test/scala/cats/tests/StreamSuite.scala
@@ -29,7 +29,7 @@ class StreamSuite extends CatsSuite {
   checkAll("Stream[Int]", MonadTests[Stream].monad[Int, Int, Int])
   checkAll("Monad[Stream]", SerializableTests.serializable(Monad[Stream]))
 
-  checkAll("Stream[Int] with Option", TraverseTests[Stream].traverse[Int, Int, Int, Set[Int], Option, Option])
+  checkAll("Stream[Int] with Option", TraverseTests[Stream].traverse[Int, Int, Int, Int, Set[Int], Option, Option])
   checkAll("Traverse[Stream]", SerializableTests.serializable(Traverse[Stream]))
 
   checkAll("Stream[Int]", TraverseFilterTests[Stream].traverseFilter[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/TrySuite.scala
+++ b/tests/src/test/scala/cats/tests/TrySuite.scala
@@ -20,7 +20,7 @@ class TrySuite extends CatsSuite {
   checkAll("Try with Throwable", MonadErrorTests[Try, Throwable].monadError[Int, Int, Int])
   checkAll("MonadError[Try, Throwable]", SerializableTests.serializable(MonadError[Try, Throwable]))
 
-  checkAll("Try[Int] with Option", TraverseTests[Try].traverse[Int, Int, Int, Int, Option, Option])
+  checkAll("Try[Int] with Option", TraverseTests[Try].traverse[Int, Int, Int, Int, Int, Option, Option])
   checkAll("Traverse[Try]", SerializableTests.serializable(Traverse[Try]))
 
   checkAll("Try", MonadTests[Try].monad[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/Tuple2KSuite.scala
+++ b/tests/src/test/scala/cats/tests/Tuple2KSuite.scala
@@ -96,7 +96,7 @@ class Tuple2KSuite extends CatsSuite {
   {
     implicit val foldable: Foldable[ListWrapper] = ListWrapper.foldable
     checkAll("Tuple2K[ListWrapper, ListWrapper, *]",
-             FoldableTests[Tuple2K[ListWrapper, ListWrapper, *]].foldable[Int, Int])
+             FoldableTests[Tuple2K[ListWrapper, ListWrapper, *]].foldable[Int, Int, Int])
     checkAll("Foldable[Tuple2K[ListWrapper, ListWrapper, *]]",
              SerializableTests.serializable(Foldable[Tuple2K[ListWrapper, ListWrapper, *]]))
   }
@@ -104,7 +104,7 @@ class Tuple2KSuite extends CatsSuite {
   {
     implicit val traverse: Traverse[ListWrapper] = ListWrapper.traverse
     checkAll("Tuple2K[ListWrapper, ListWrapper, *]",
-             TraverseTests[Tuple2K[ListWrapper, ListWrapper, *]].traverse[Int, Int, Int, Int, Option, Option])
+             TraverseTests[Tuple2K[ListWrapper, ListWrapper, *]].traverse[Int, Int, Int, Int, Int, Option, Option])
     checkAll("Traverse[Tuple2K[ListWrapper, ListWrapper, *]]",
              SerializableTests.serializable(Traverse[Tuple2K[ListWrapper, ListWrapper, *]]))
   }

--- a/tests/src/test/scala/cats/tests/TupleSuite.scala
+++ b/tests/src/test/scala/cats/tests/TupleSuite.scala
@@ -16,7 +16,8 @@ class TupleSuite extends CatsSuite {
   checkAll("Tuple2", BitraverseTests[Tuple2].bitraverse[Option, Int, Int, Int, String, String, String])
   checkAll("Bitraverse[Tuple2]", SerializableTests.serializable(Bitraverse[Tuple2]))
 
-  checkAll("Tuple2[String, Int] with Option", TraverseTests[(String, *)].traverse[Int, Int, Int, Int, Option, Option])
+  checkAll("Tuple2[String, Int] with Option",
+           TraverseTests[(String, *)].traverse[Int, Int, Int, Int, Int, Option, Option])
   checkAll("Traverse[(String, *)]", SerializableTests.serializable(Traverse[(String, *)]))
 
   checkAll("Tuple2[String, Int]", ComonadTests[(String, *)].comonad[Int, Int, Int])
@@ -37,7 +38,7 @@ class TupleSuite extends CatsSuite {
   checkAll("CommutativeMonad[(Int, *)]", CommutativeMonadTests[(Int, *)].commutativeMonad[Int, Int, Int])
   checkAll("CommutativeMonad[(Int, *)] serializable", SerializableTests.serializable(CommutativeMonad[(Int, *)]))
 
-  checkAll("Tuple2[String, Int]", ReducibleTests[(String, *)].reducible[Option, Int, Int])
+  checkAll("Tuple2[String, Int]", ReducibleTests[(String, *)].reducible[Option, Int, Int, Int])
   checkAll("Reducible[(String, *)]", SerializableTests.serializable(Reducible[(String, *)]))
 
   test("Semigroupal composition") {

--- a/tests/src/test/scala/cats/tests/UnorderedFoldableSuite.scala
+++ b/tests/src/test/scala/cats/tests/UnorderedFoldableSuite.scala
@@ -44,7 +44,7 @@ sealed abstract class UnorderedFoldableSuite[F[_]](name: String)(implicit ArbFSt
       fa.count(Function.const(true)) should ===(fa.size)
     }
   }
-  checkAll("F[Int]", UnorderedFoldableTests[F](instance).unorderedFoldable[Int, Int])
+  checkAll("F[Int]", UnorderedFoldableTests[F](instance).unorderedFoldable[Int, Int, Int])
 }
 
 final class UnorderedFoldableSetSuite extends UnorderedFoldableSuite[Set]("set") {

--- a/tests/src/test/scala/cats/tests/ValidatedSuite.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedSuite.scala
@@ -29,7 +29,7 @@ class ValidatedSuite extends CatsSuite {
            SerializableTests.serializable(ApplicativeError[Validated[String, *], String]))
 
   checkAll("Validated[String, Int] with Option",
-           TraverseTests[Validated[String, *]].traverse[Int, Int, Int, Int, Option, Option])
+           TraverseTests[Validated[String, *]].traverse[Int, Int, Int, Int, Int, Option, Option])
   checkAll("Traverse[Validated[String, *]]", SerializableTests.serializable(Traverse[Validated[String, *]]))
 
   checkAll("Validated[String, Int]", OrderTests[Validated[String, Int]].order)

--- a/tests/src/test/scala/cats/tests/VectorSuite.scala
+++ b/tests/src/test/scala/cats/tests/VectorSuite.scala
@@ -26,7 +26,7 @@ class VectorSuite extends CatsSuite {
   checkAll("Vector[Int]", AlternativeTests[Vector].alternative[Int, Int, Int])
   checkAll("Alternative[Vector]", SerializableTests.serializable(Alternative[Vector]))
 
-  checkAll("Vector[Int] with Option", TraverseTests[Vector].traverse[Int, Int, Int, Set[Int], Option, Option])
+  checkAll("Vector[Int] with Option", TraverseTests[Vector].traverse[Int, Int, Int, Int, Set[Int], Option, Option])
   checkAll("Traverse[Vector]", SerializableTests.serializable(Traverse[Vector]))
 
   checkAll("Vector[Int]", MonadTests[Vector].monad[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/WriterTSuite.scala
+++ b/tests/src/test/scala/cats/tests/WriterTSuite.scala
@@ -450,7 +450,7 @@ class WriterTSuite extends CatsSuite {
     Foldable[WriterT[Const[String, *], ListWrapper[Int], *]]
 
     checkAll("WriterT[Const[String, *], ListWrapper[Int], *]",
-             FoldableTests[WriterT[Const[String, *], ListWrapper[Int], *]].foldable[Int, Int])
+             FoldableTests[WriterT[Const[String, *], ListWrapper[Int], *]].foldable[Int, Int, Int])
     checkAll("Foldable[WriterT[Const[String, *], ListWrapper[Int], *]]",
              SerializableTests.serializable(Foldable[WriterT[Const[String, *], ListWrapper[Int], *]]))
 
@@ -458,7 +458,8 @@ class WriterTSuite extends CatsSuite {
     Foldable[WriterT[Id, ListWrapper[Int], *]]
     Foldable[Writer[ListWrapper[Int], *]]
 
-    checkAll("WriterT[Id, ListWrapper[Int], *]", FoldableTests[WriterT[Id, ListWrapper[Int], *]].foldable[Int, Int])
+    checkAll("WriterT[Id, ListWrapper[Int], *]",
+             FoldableTests[WriterT[Id, ListWrapper[Int], *]].foldable[Int, Int, Int])
   }
 
   {
@@ -467,8 +468,10 @@ class WriterTSuite extends CatsSuite {
     Traverse[Const[String, *]]
     Traverse[WriterT[Const[String, *], ListWrapper[Int], *]]
 
-    checkAll("WriterT[Const[String, *], ListWrapper[Int], *]",
-             TraverseTests[WriterT[Const[String, *], ListWrapper[Int], *]].traverse[Int, Int, Int, Int, Option, Option])
+    checkAll(
+      "WriterT[Const[String, *], ListWrapper[Int], *]",
+      TraverseTests[WriterT[Const[String, *], ListWrapper[Int], *]].traverse[Int, Int, Int, Int, Int, Option, Option]
+    )
     checkAll("Traverse[WriterT[Const[String, *], ListWrapper[Int], *]]",
              SerializableTests.serializable(Traverse[WriterT[Const[String, *], ListWrapper[Int], *]]))
 
@@ -477,7 +480,7 @@ class WriterTSuite extends CatsSuite {
     Traverse[Writer[ListWrapper[Int], *]]
 
     checkAll("WriterT[Id, ListWrapper[Int], *]",
-             TraverseTests[WriterT[Id, ListWrapper[Int], *]].traverse[Int, Int, Int, Int, Option, Option])
+             TraverseTests[WriterT[Id, ListWrapper[Int], *]].traverse[Int, Int, Int, Int, Int, Option, Option])
   }
 
   {


### PR DESCRIPTION
Follow up of https://github.com/typelevel/cats/pull/3309. It introduces, 

* Laws for `minimumOption`, `maximumOption`, `minimumByOption`, `maximumByOption`. The laws determine a full spec of these operations. 

* Tests for `minimumOption`, `maximumOption`.

TODO: include the tests for `minimumByOption`, `maximumByOption`.

Notes: `FoldableOps#contains_` could be moved to `UnorderedFoldableOps#contains_`. This operation could then be used in the laws above.  
